### PR TITLE
Fix ESPConnectClass::erase() to clear wifi credentials on ESP8266

### DIFF
--- a/src/ESPConnect.cpp
+++ b/src/ESPConnect.cpp
@@ -239,6 +239,14 @@ bool ESPConnectClass::begin(AsyncWebServer* server, unsigned long timeout){
 */
 bool ESPConnectClass::erase(){
   #if defined(ESP8266)
+// -----------  Added this section to erase stored wifi credentials - RLB -20220318  --------
+	int ok = 0;
+    struct station_config	config = {};
+	memset(&config.ssid, 0, sizeof(config.ssid));
+	memset(&config.password, 0, sizeof(config.password));
+    config.bssid_set = false;
+    ok = wifi_station_set_config(&config);
+// -----------------------------------------------------------------------------------------
     return WiFi.disconnect(true);
   #elif defined(ESP32)
     Preferences preferences;
@@ -261,6 +269,10 @@ bool ESPConnectClass::isConnected(){
 
 String ESPConnectClass::getSSID(){
   return _sta_ssid;
+}
+
+String ESPConnectClass::getPassword(){
+  return _sta_password;
 }
 
 ESPConnectClass ESPConnect;

--- a/src/ESPConnect.cpp
+++ b/src/ESPConnect.cpp
@@ -240,10 +240,10 @@ bool ESPConnectClass::begin(AsyncWebServer* server, unsigned long timeout){
 bool ESPConnectClass::erase(){
   #if defined(ESP8266)
 // -----------  Added this section to erase stored wifi credentials - RLB -20220318  --------
-	int ok = 0;
+    int ok = 0;
     struct station_config	config = {};
-	memset(&config.ssid, 0, sizeof(config.ssid));
-	memset(&config.password, 0, sizeof(config.password));
+    memset(&config.ssid, 0, sizeof(config.ssid));
+    memset(&config.password, 0, sizeof(config.password));
     config.bssid_set = false;
     ok = wifi_station_set_config(&config);
 // -----------------------------------------------------------------------------------------

--- a/src/ESPConnect.h
+++ b/src/ESPConnect.h
@@ -75,6 +75,7 @@ class ESPConnectClass {
 
     // Gets SSID of connected endpoint
     String getSSID();
+	String getPassword();
 };
 
 extern ESPConnectClass ESPConnect;

--- a/src/ESPConnect.h
+++ b/src/ESPConnect.h
@@ -75,7 +75,7 @@ class ESPConnectClass {
 
     // Gets SSID of connected endpoint
     String getSSID();
-	String getPassword();
+    String getPassword();
 };
 
 extern ESPConnectClass ESPConnect;


### PR DESCRIPTION
This change fixes the erase() function to work with ESP8266.  
Also added a new function getPassword() to complement getSSID().  